### PR TITLE
Create includedir_server directory when installing headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ rum--1.0--1.1.sql: Makefile gen_rum_sql--1.0--1.1.pl
 install: installincludes
 
 installincludes:
+	$(INSTALL) -d '$(DESTDIR)$(includedir_server)/'
 	$(INSTALL_DATA) $(addprefix $(srcdir)/, $(INCLUDES)) '$(DESTDIR)$(includedir_server)/'
 
 ISOLATIONCHECKS= predicate-rum predicate-rum-2


### PR DESCRIPTION
When using DESTDIR, the target directory is likely not yet existent,
create it from the installincludes rule.