### PR TITLE
Fix for v13 API changes

### DIFF
--- a/src/rumutil.c
+++ b/src/rumutil.c
@@ -83,13 +83,25 @@ _PG_init(void)
 
 	add_string_reloption(rum_relopt_kind, "attach",
 						 "Column name to attach as additional info",
-						 NULL, NULL);
+						 NULL, NULL
+#if PG_VERSION_NUM >= 130000
+						 ,AccessExclusiveLock
+#endif
+						);
 	add_string_reloption(rum_relopt_kind, "to",
 						 "Column name to add a order by column",
-						 NULL, NULL);
+						 NULL, NULL
+#if PG_VERSION_NUM >= 130000
+						 ,AccessExclusiveLock
+#endif
+						);
 	add_bool_reloption(rum_relopt_kind, "order_by_attach",
 			  "Use (addinfo, itempointer) order instead of just itempointer",
-					   false);
+					   false
+#if PG_VERSION_NUM >= 130000
+						 ,AccessExclusiveLock
+#endif
+						);
 }
 
 /*


### PR DESCRIPTION
"add_string_reloption" now requires a lock mode, since
commit 69f94108079d70093b59096a3ae0ad82c842b4c0

make installcheck passes on 11.5, 12.0, and 13dev.