### PR TITLE
Travis config fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-sudo: required
+os: linux
+
+dist: bionic
 
 language: c
 
@@ -21,6 +23,8 @@ notifications:
         on_failure: always
 
 env:
+    - PG_VERSION=15beta1
+    - PG_VERSION=15beta1 LEVEL=hardcore
     - PG_VERSION=14
     - PG_VERSION=14 LEVEL=hardcore
     - PG_VERSION=13

--- a/src/disable_core_macro.h
+++ b/src/disable_core_macro.h
@@ -18,10 +18,11 @@
 
 #if PG_VERSION_NUM >= 110000
 #define TRACE_POSTGRESQL_SORT_START(arg1, arg2, arg3, arg4, arg5, arg6) \
+			do {} while(0)
 #else
 #define TRACE_POSTGRESQL_SORT_START(arg1, arg2, arg3, arg4, arg5) \
-#endif
 			do {} while(0)
+#endif
 
 
 #define TRACE_POSTGRESQL_SORT_DONE(arg1, arg2) \

--- a/src/disable_core_macro.h
+++ b/src/disable_core_macro.h
@@ -16,9 +16,17 @@
 #undef TRACE_POSTGRESQL_SORT_START
 #undef TRACE_POSTGRESQL_SORT_DONE
 
+#if PG_VERSION_NUM >= 110000
 #define TRACE_POSTGRESQL_SORT_START(arg1, arg2, arg3, arg4, arg5, arg6) \
+#else
+#define TRACE_POSTGRESQL_SORT_START(arg1, arg2, arg3, arg4, arg5) \
+#endif
 			do {} while(0)
+
+
 #define TRACE_POSTGRESQL_SORT_DONE(arg1, arg2) \
 			do {} while(0)
+
+
 
 #endif /* __DISABLE_CORE_MACRO_H__ */

--- a/src/tuplesort15.c
+++ b/src/tuplesort15.c
@@ -2946,6 +2946,7 @@ selectnewtape(Tuplesortstate *state)
 		 * We have reached the max number of tapes.  Append to an existing
 		 * tape.
 		 */
+		Assert(state->nOutputTapes != 0);
 		state->destTape = state->outputTapes[state->nOutputRuns % state->nOutputTapes];
 		state->nOutputRuns++;
 	}


### PR DESCRIPTION
* add 15beta1 to travis config
* fix travis warnings
    root: deprecated key sudo (The key `sudo` has no effect anymore.)
    root: missing dist, using the default xenial
    root: missing os, using the default linux
* fix gcc-7.5.0 preprocessor error
* fix clang scan-build warning