### PR TITLE
Fix compiler warnings due to new checks in PostgreSQL 16

### DIFF
--- a/src/rumget.c
+++ b/src/rumget.c
@@ -632,7 +632,6 @@ restartScanEntry:
 		{
 			BlockNumber rootPostingTree = RumGetPostingTree(itup);
 			RumPostingTreeScan *gdi;
-			Page		page;
 			OffsetNumber maxoff,
 						i;
 			Pointer		ptr;
@@ -1051,7 +1050,6 @@ entryGetNextItemList(RumState * rumstate, RumScanEntry entry, Snapshot snapshot)
 	{
 		BlockNumber rootPostingTree = RumGetPostingTree(itup);
 		RumPostingTreeScan *gdi;
-		Page		page;
 		OffsetNumber maxoff,
 					i;
 		Pointer		ptr;

--- a/src/ruminsert.c
+++ b/src/ruminsert.c
@@ -530,11 +530,11 @@ rumHeapTupleBulkInsert(RumBuildState * buildstate, OffsetNumber attnum,
 			/* Check existance of additional information attribute in index */
 			if (!attr)
 			{
-				Form_pg_attribute attr = RumTupleDescAttr(
+				Form_pg_attribute current_attr = RumTupleDescAttr(
 					buildstate->rumstate.origTupdesc, attnum - 1);
 
 				elog(ERROR, "additional information attribute \"%s\" is not found in index",
-					 NameStr(attr->attname));
+					 NameStr(current_attr->attname));
 			}
 
 			addInfo[i] = datumCopy(addInfo[i], attr->attbyval, attr->attlen);


### PR DESCRIPTION
See the commit 0fe954c28584169938e5c0738cfaa9930ce77577 (Add -Wshadow=compatible-local to the standard compilation flags) in PostgreSQL 16.

```
src/ruminsert.c: In function ‘rumHeapTupleBulkInsert’:
src/ruminsert.c:533:51: warning: declaration of ‘attr’ shadows a previous local [-Wshadow=compatible-local]
  533 |                                 Form_pg_attribute attr = RumTupleDescAttr(
      |                                                   ^~~~
src/ruminsert.c:505:27: note: shadowed declaration is here
  505 |         Form_pg_attribute attr = buildstate->rumstate.addAttrs[attnum - 1];
      |                           ^~~~
src/rumget.c: In function ‘startScanEntry’:
src/rumget.c:635:41: warning: declaration of ‘page’ shadows a previous local [-Wshadow=compatible-local]
  635 |                         Page            page;
      |                                         ^~~~
src/rumget.c:548:25: note: shadowed declaration is here
  548 |         Page            page;
      |                         ^~~~
src/rumget.c: In function ‘entryGetNextItemList’:
src/rumget.c:1054:33: warning: declaration of ‘page’ shadows a previous local [-Wshadow=compatible-local]
 1054 |                 Page            page;
      |                                 ^~~~
src/rumget.c:986:25: note: shadowed declaration is here
  986 |         Page            page;
      |                         ^~~~
```