### PR TITLE
In PG 17, the signature for tuplesort_puttuple_common changed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ notifications:
         on_failure: always
 
 env:
+    - PG_VERSION=17
+    - PG_VERSION=17 LEVEL=hardcore
     - PG_VERSION=16
     - PG_VERSION=16 LEVEL=hardcore
     - PG_VERSION=15

--- a/src/rumsort.c
+++ b/src/rumsort.c
@@ -492,11 +492,14 @@ rum_tuplesort_putrum(RumTuplesortstate *state, RumSortItem *item)
 	oldcontext = MemoryContextSwitchTo(rum_tuplesort_get_memorycontext(state));
 	copytup_rum(state, &stup, item);
 
-#if PG_VERSION_NUM >= 160000
+#if PG_VERSION_NUM >= 170000
+	tuplesort_puttuple_common(state, &stup, false, GetMemoryChunkSpace(&stup));
+#elif PG_VERSION_NUM == 160000
 	tuplesort_puttuple_common(state, &stup, false);
 #else
 	puttuple_common(state, &stup);
 #endif
+
 
 	MemoryContextSwitchTo(oldcontext);
 }
@@ -510,7 +513,9 @@ rum_tuplesort_putrumitem(RumTuplesortstate *state, RumScanItem *item)
 	oldcontext = MemoryContextSwitchTo(rum_tuplesort_get_memorycontext(state));
 	copytup_rumitem(state, &stup, item);
 
-#if PG_VERSION_NUM >= 160000
+#if PG_VERSION_NUM >= 170000
+	tuplesort_puttuple_common(state, &stup, false, GetMemoryChunkSpace(&stup));
+#elif PG_VERSION_NUM == 160000
 	tuplesort_puttuple_common(state, &stup, false);
 #else
 	puttuple_common(state, &stup);


### PR DESCRIPTION
Fixes #127 

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=6ed83d5fa55cf6e6c9d1be34ec10730c48eba763