### PR TITLE
[PGPRO-11393] Fixed the content of the error message

### DIFF
--- a/expected/orderby.out
+++ b/expected/orderby.out
@@ -460,6 +460,11 @@ SELECT id, d FROM tsts WHERE  t @@ 'wr&qh' AND d >= '2016-05-16 14:21:25' ORDER 
  458 | Fri May 20 21:21:22.326724 2016
 (3 rows)
 
+-- Test "ORDER BY" error message
+DROP INDEX tsts_idx;
+CREATE INDEX tsts_idx ON tsts USING rum (t rum_tsvector_addon_ops, d);
+SELECT id, d, d <=> '2016-05-16 14:21:25' FROM tsts WHERE t @@ 'wr&qh' ORDER BY d <=> '2016-05-16 14:21:25' LIMIT 5;
+ERROR:  cannot order without attribute 2 in ORDER BY clause
 -- Test multicolumn index
 RESET enable_indexscan;
 RESET enable_indexonlyscan;

--- a/sql/orderby.sql
+++ b/sql/orderby.sql
@@ -95,6 +95,13 @@ SELECT id, d FROM tsts WHERE  t @@ 'wr&qh' AND d <= '2016-05-16 14:21:25' ORDER 
 SELECT id, d FROM tsts WHERE  t @@ 'wr&qh' AND d >= '2016-05-16 14:21:25' ORDER BY d ASC LIMIT 3;
 SELECT id, d FROM tsts WHERE  t @@ 'wr&qh' AND d >= '2016-05-16 14:21:25' ORDER BY d DESC LIMIT 3;
 
+-- Test "ORDER BY" error message
+DROP INDEX tsts_idx;
+
+CREATE INDEX tsts_idx ON tsts USING rum (t rum_tsvector_addon_ops, d);
+
+SELECT id, d, d <=> '2016-05-16 14:21:25' FROM tsts WHERE t @@ 'wr&qh' ORDER BY d <=> '2016-05-16 14:21:25' LIMIT 5;
+
 -- Test multicolumn index
 
 RESET enable_indexscan;

--- a/src/rumscan.c
+++ b/src/rumscan.c
@@ -214,7 +214,7 @@ rumFillScanKey(RumScanOpaque so, OffsetNumber attnum,
 				}
 
 				if (scanKey == NULL)
-					elog(ERROR, "cannot order without attribute %d in WHERE clause",
+					elog(ERROR, "cannot order without attribute %d in ORDER BY clause",
 						 key->attnum);
 				else if (scanKey->nentries > 1)
 					elog(ERROR, "scan key should contain only one value");


### PR DESCRIPTION
If the "RUM" index was created without the "WITH" operator, when "SELECT...ORDER BY" an error message of the form would appear:

  "ERROR: cannot order without attribute ... in WHERE clause"

Fixed the content of error message, "WHERE" replaced by "ORDER BY".

Tags: rum