### PR TITLE
32-bit outputs

### DIFF
--- a/expected/altorder.out
+++ b/expected/altorder.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * altorder.out - test output for 64-bit systems and
+ * altorder_1.out - test output for 32-bit systems.
+ *
+ */
 CREATE TABLE atsts (id int, t tsvector, d timestamp);
 \copy atsts from 'data/tsts.data'
 -- PGPRO-2537: We need more data to test rumsort.c with logtape.c

--- a/expected/altorder_1.out
+++ b/expected/altorder_1.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * altorder.out - test output for 64-bit systems and
+ * altorder_1.out - test output for 32-bit systems.
+ *
+ */
 CREATE TABLE atsts (id int, t tsvector, d timestamp);
 \copy atsts from 'data/tsts.data'
 -- PGPRO-2537: We need more data to test rumsort.c with logtape.c

--- a/expected/altorder_hash.out
+++ b/expected/altorder_hash.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * altorder_hash.out - test output for 64-bit systems and
+ * altorder_hash_1.out - test output for 32-bit systems.
+ *
+ */
 CREATE TABLE atstsh (id int, t tsvector, d timestamp);
 \copy atstsh from 'data/tsts.data'
 CREATE INDEX atstsh_idx ON atstsh USING rum (t rum_tsvector_hash_addon_ops, d)

--- a/expected/altorder_hash_1.out
+++ b/expected/altorder_hash_1.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * altorder_hash.out - test output for 64-bit systems and
+ * altorder_hash_1.out - test output for 32-bit systems.
+ *
+ */
 CREATE TABLE atstsh (id int, t tsvector, d timestamp);
 \copy atstsh from 'data/tsts.data'
 CREATE INDEX atstsh_idx ON atstsh USING rum (t rum_tsvector_hash_addon_ops, d)

--- a/expected/array.out
+++ b/expected/array.out
@@ -1,12 +1,11 @@
 /*
- * ---------------------------------------------
- *  NOTE: This test behaves differenly on PgPro
- * ---------------------------------------------
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
  *
- * --------------------
- *  array.sql and array_1.sql
- * --------------------
- * Test output for 64-bit and 32-bit systems respectively.
+ * array.out - test output for 64-bit systems and
+ * array_1.out - test output for 32-bit systems.
+ *
  */
 set enable_seqscan=off;
 set enable_sort=off;

--- a/expected/array_1.out
+++ b/expected/array_1.out
@@ -1,12 +1,11 @@
 /*
- * ---------------------------------------------
- *  NOTE: This test behaves differenly on PgPro
- * ---------------------------------------------
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
  *
- * --------------------
- *  array.sql and array_1.sql
- * --------------------
- * Test output for 64-bit and 32-bit systems respectively.
+ * array.out - test output for 64-bit systems and
+ * array_1.out - test output for 32-bit systems.
+ *
  */
 set enable_seqscan=off;
 set enable_sort=off;

--- a/expected/float8.out
+++ b/expected/float8.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * float8.out - test output for 64-bit systems and
+ * float8_1.out - test output for 32-bit systems.
+ *
+ */
 set enable_seqscan=off;
 CREATE TABLE test_float8 (
 	i float8

--- a/expected/float8_1.out
+++ b/expected/float8_1.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * float8.out - test output for 64-bit systems and
+ * float8_1.out - test output for 32-bit systems.
+ *
+ */
 set enable_seqscan=off;
 CREATE TABLE test_float8 (
 	i float8

--- a/expected/int8.out
+++ b/expected/int8.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * int8.out - test output for 64-bit systems and
+ * int8_1.out - test output for 32-bit systems.
+ *
+ */
 set enable_seqscan=off;
 CREATE TABLE test_int8 (
 	i int8

--- a/expected/int8_1.out
+++ b/expected/int8_1.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * int8.out - test output for 64-bit systems and
+ * int8_1.out - test output for 32-bit systems.
+ *
+ */
 set enable_seqscan=off;
 CREATE TABLE test_int8 (
 	i int8

--- a/expected/money.out
+++ b/expected/money.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * money.out - test output for 64-bit systems and
+ * money_1.out - test output for 32-bit systems.
+ *
+ */
 set enable_seqscan=off;
 CREATE TABLE test_money (
 	i money

--- a/expected/money_1.out
+++ b/expected/money_1.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * money.out - test output for 64-bit systems and
+ * money_1.out - test output for 32-bit systems.
+ *
+ */
 set enable_seqscan=off;
 CREATE TABLE test_money (
 	i money

--- a/expected/orderby.out
+++ b/expected/orderby.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * orderby.out - test output for 64-bit systems and
+ * orderby_1.out - test output for 32-bit systems.
+ *
+ */
 CREATE TABLE tsts (id int, t tsvector, d timestamp);
 \copy tsts from 'data/tsts.data'
 CREATE INDEX tsts_idx ON tsts USING rum (t rum_tsvector_addon_ops, d)

--- a/expected/orderby_1.out
+++ b/expected/orderby_1.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * orderby.out - test output for 64-bit systems and
+ * orderby_1.out - test output for 32-bit systems.
+ *
+ */
 CREATE TABLE tsts (id int, t tsvector, d timestamp);
 \copy tsts from 'data/tsts.data'
 CREATE INDEX tsts_idx ON tsts USING rum (t rum_tsvector_addon_ops, d)
@@ -420,6 +429,11 @@ SELECT id, d FROM tsts WHERE  t @@ 'wr&qh' AND d >= '2016-05-16 14:21:25' ORDER 
  458 | Fri May 20 21:21:22.326724 2016
 (3 rows)
 
+-- Test "ORDER BY" error message
+DROP INDEX tsts_idx;
+CREATE INDEX tsts_idx ON tsts USING rum (t rum_tsvector_addon_ops, d);
+SELECT id, d, d <=> '2016-05-16 14:21:25' FROM tsts WHERE t @@ 'wr&qh' ORDER BY d <=> '2016-05-16 14:21:25' LIMIT 5;
+ERROR:  doesn't support order by over pass-by-reference column
 -- Test multicolumn index
 RESET enable_indexscan;
 RESET enable_indexonlyscan;

--- a/expected/orderby_hash.out
+++ b/expected/orderby_hash.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * orderby_hash.out - test output for 64-bit systems and
+ * orderby_hash_1.out - test output for 32-bit systems.
+ *
+ */
 CREATE TABLE tstsh (id int, t tsvector, d timestamp);
 \copy tstsh from 'data/tsts.data'
 CREATE INDEX tstsh_idx ON tstsh USING rum (t rum_tsvector_hash_addon_ops, d)

--- a/expected/orderby_hash_1.out
+++ b/expected/orderby_hash_1.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * orderby_hash.out - test output for 64-bit systems and
+ * orderby_hash_1.out - test output for 32-bit systems.
+ *
+ */
 CREATE TABLE tstsh (id int, t tsvector, d timestamp);
 \copy tstsh from 'data/tsts.data'
 CREATE INDEX tstsh_idx ON tstsh USING rum (t rum_tsvector_hash_addon_ops, d)

--- a/expected/timestamp.out
+++ b/expected/timestamp.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * timestamp.out - test output for 64-bit systems and
+ * timestamp_1.out - test output for 32-bit systems.
+ *
+ */
 CREATE TABLE test_timestamp (
 	i timestamp
 );

--- a/expected/timestamp_1.out
+++ b/expected/timestamp_1.out
@@ -1,3 +1,12 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * timestamp.out - test output for 64-bit systems and
+ * timestamp_1.out - test output for 32-bit systems.
+ *
+ */
 CREATE TABLE test_timestamp (
 	i timestamp
 );

--- a/sql/altorder.sql
+++ b/sql/altorder.sql
@@ -1,3 +1,14 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * altorder.out - test output for 64-bit systems and
+ * altorder_1.out - test output for 32-bit systems.
+ *
+ */
+
+
 CREATE TABLE atsts (id int, t tsvector, d timestamp);
 
 \copy atsts from 'data/tsts.data'

--- a/sql/altorder_hash.sql
+++ b/sql/altorder_hash.sql
@@ -1,3 +1,14 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * altorder_hash.out - test output for 64-bit systems and
+ * altorder_hash_1.out - test output for 32-bit systems.
+ *
+ */
+
+
 CREATE TABLE atstsh (id int, t tsvector, d timestamp);
 
 \copy atstsh from 'data/tsts.data'

--- a/sql/array.sql
+++ b/sql/array.sql
@@ -1,12 +1,11 @@
 /*
- * ---------------------------------------------
- *  NOTE: This test behaves differenly on PgPro
- * ---------------------------------------------
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
  *
- * --------------------
- *  array.sql and array_1.sql
- * --------------------
- * Test output for 64-bit and 32-bit systems respectively.
+ * array.out - test output for 64-bit systems and
+ * array_1.out - test output for 32-bit systems.
+ *
  */
 
 

--- a/sql/float8.sql
+++ b/sql/float8.sql
@@ -1,3 +1,14 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * float8.out - test output for 64-bit systems and
+ * float8_1.out - test output for 32-bit systems.
+ *
+ */
+
+
 set enable_seqscan=off;
 
 CREATE TABLE test_float8 (

--- a/sql/int8.sql
+++ b/sql/int8.sql
@@ -1,3 +1,14 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * int8.out - test output for 64-bit systems and
+ * int8_1.out - test output for 32-bit systems.
+ *
+ */
+
+
 set enable_seqscan=off;
 
 CREATE TABLE test_int8 (

--- a/sql/money.sql
+++ b/sql/money.sql
@@ -1,3 +1,14 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * money.out - test output for 64-bit systems and
+ * money_1.out - test output for 32-bit systems.
+ *
+ */
+
+
 set enable_seqscan=off;
 
 CREATE TABLE test_money (

--- a/sql/orderby.sql
+++ b/sql/orderby.sql
@@ -1,3 +1,14 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * orderby.out - test output for 64-bit systems and
+ * orderby_1.out - test output for 32-bit systems.
+ *
+ */
+
+
 CREATE TABLE tsts (id int, t tsvector, d timestamp);
 
 \copy tsts from 'data/tsts.data'

--- a/sql/orderby_hash.sql
+++ b/sql/orderby_hash.sql
@@ -1,3 +1,14 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * orderby_hash.out - test output for 64-bit systems and
+ * orderby_hash_1.out - test output for 32-bit systems.
+ *
+ */
+
+
 CREATE TABLE tstsh (id int, t tsvector, d timestamp);
 
 \copy tstsh from 'data/tsts.data'

--- a/sql/timestamp.sql
+++ b/sql/timestamp.sql
@@ -1,3 +1,13 @@
+/*
+ * ------------------------------------
+ *  NOTE: This test behaves differenly
+ * ------------------------------------
+ *
+ * timestamp.out - test output for 64-bit systems and
+ * timestamp_1.out - test output for 32-bit systems.
+ *
+ */
+
 
 CREATE TABLE test_timestamp (
 	i timestamp


### PR DESCRIPTION
1) Update alternative output of orderby.sql for 32-bit systems
2) Add comments in all regress tests with alternatives