### PR TITLE
Run regression tests with a parallel schedule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,7 @@ RELATIVE_INCLUDES = $(addprefix src/, $(INCLUDES))
 
 LDFLAGS_SL += $(filter -lm, $(LIBS))
 
-REGRESS = security rum rum_validate rum_hash ruminv timestamp orderby orderby_hash \
-	altorder altorder_hash limits \
-	int2 int4 int8 float4 float8 money oid \
-    time timetz date interval \
-    macaddr inet cidr text varchar char bytea bit varbit \
-	numeric rum_weight expr
+REGRESS = --schedule=$(srcdir)/regress_schedule
 
 TAP_TESTS = 1
 

--- a/regress_schedule
+++ b/regress_schedule
@@ -1,0 +1,12 @@
+# "security" and "rum" are setup, and must be run sequentially.
+test: security
+test: rum
+
+# up to 20 tests in a single parallel schedule
+test: rum_validate rum_hash ruminv timestamp orderby \
+    orderby_hash altorder altorder_hash limits int2 \
+    int4 int8 float4 float8 money \
+    oid time timetz date interval
+test: macaddr inet cidr text varchar \
+    char bytea bit varbit numeric \
+    rum_weight expr


### PR DESCRIPTION
This reduces the time it takes to run these tests on systems that have many CPUs available.