### PR TITLE
Fix corruption when entry->buffer changed to nonleaf while unlocked.

### DIFF
--- a/src/rumget.c
+++ b/src/rumget.c
@@ -889,7 +889,14 @@ entryGetNextItem(RumState * rumstate, RumScanEntry entry, Snapshot snapshot)
 
 		LockBuffer(entry->buffer, RUM_SHARE);
 		page = BufferGetPage(entry->buffer);
-
+		if (!RumPageIsLeaf(page))
+		{
+			/*
+			 * Root page becomes non-leaf while we unlock it. just return.
+			 */
+			 LockBuffer(entry->buffer, RUM_UNLOCK);
+			 return;
+		}
 		PredicateLockPage(rumstate->index, BufferGetBlockNumber(entry->buffer), snapshot);
 
 		if (scanPage(rumstate, entry, &entry->curItem, false))


### PR DESCRIPTION
Details in [issue#144](https://github.com/postgrespro/rum/issues/144).