### PR TITLE
Set up a dictionary to uniquely identify test data

### DIFF
--- a/expected/predicate-rum-2.out
+++ b/expected/predicate-rum-2.out
@@ -5,10 +5,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('ab');
@@ -31,10 +31,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('ab');
@@ -57,10 +57,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('ab');
@@ -83,10 +83,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('ab');
@@ -109,10 +109,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -135,10 +135,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -161,10 +161,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -187,10 +187,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -213,10 +213,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -239,10 +239,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -275,10 +275,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('ab');
@@ -301,10 +301,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('ab');
@@ -327,10 +327,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('ab');
@@ -353,10 +353,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wy2: INSERT INTO rum_tbl(tsv) values('xz');
@@ -379,10 +379,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wy2: INSERT INTO rum_tbl(tsv) values('xz');
@@ -405,10 +405,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wy2: INSERT INTO rum_tbl(tsv) values('xz');
@@ -432,10 +432,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('ab');
@@ -458,10 +458,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('ab');
@@ -484,10 +484,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step c2: COMMIT;
@@ -511,10 +511,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('ab');

--- a/expected/predicate-rum.out
+++ b/expected/predicate-rum.out
@@ -5,10 +5,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('qh');
@@ -32,10 +32,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('qh');
@@ -58,10 +58,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('qh');
@@ -84,10 +84,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('qh');
@@ -110,10 +110,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -136,10 +136,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -162,10 +162,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -188,10 +188,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -214,10 +214,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -240,10 +240,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step rxy2: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'qh';
@@ -276,10 +276,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('qh');
@@ -302,10 +302,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('qh');
@@ -328,10 +328,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('qh');
@@ -354,10 +354,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wy2: INSERT INTO rum_tbl(tsv) values('hx');
@@ -380,10 +380,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wy2: INSERT INTO rum_tbl(tsv) values('hx');
@@ -406,10 +406,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wy2: INSERT INTO rum_tbl(tsv) values('hx');
@@ -433,10 +433,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('qh');
@@ -459,10 +459,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step wx1: INSERT INTO rum_tbl(tsv) values('qh');
@@ -485,10 +485,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 (5 rows)
 
 step c2: COMMIT;
@@ -512,10 +512,10 @@ step rxy1: SELECT id, tsv FROM rum_tbl WHERE tsv @@ 'hx';
  id|tsv                                                                   
 ---+----------------------------------------------------------------------
  28|'aq':3 'eo':9 'ep':6 'fh':4 'hi':1 'hx':8 'jz':2 'pf':10 'xy':5 'zg':7
- 96|'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':8 'xy':1 'zg':3               
+ 96|'an':8 'be':9 'eo':5 'ep':2 'hx':4 'nw':7 'pf':6 'pv':10 'xy':1 'zg':3
 163|'aq':5 'ep':8 'fh':6 'hi':3 'hx':10 'jz':4 'sa':1 'sr':2 'xy':7 'zg':9
-231|'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5        
-299|'eo':3 'hx':2 'jd':8 'nw':5 'pf':4 'pv':6 'sm':7 'zg':1               
+231|'an':10 'aq':1 'eo':7 'ep':4 'fh':2 'hx':6 'nw':9 'pf':8 'xy':3 'zg':5
+299|'an':6 'be':7 'eo':3 'hx':2 'jd':10 'nw':5 'pf':4 'pv':8 'sm':9 'zg':1
 339|'hx'                                                                  
 (6 rows)
 

--- a/specs/predicate-rum-2.spec
+++ b/specs/predicate-rum-2.spec
@@ -26,7 +26,7 @@ setup
  FOR i in 1..338 LOOP
 	INSERT INTO rum_tbl(tsv) VALUES ('');
 	FOR j in 1..10 LOOP 
-		UPDATE rum_tbl SET tsv = tsv || (SELECT to_tsvector(t[1]) FROM text_table WHERE id1 = Xi % 676 + 1) WHERE id = i;
+		UPDATE rum_tbl SET tsv = tsv || (SELECT to_tsvector('simple', t[1]) FROM text_table WHERE id1 = Xi % 676 + 1) WHERE id = i;
 		Xi = (a * Xi + c) % m;
  	END LOOP;
  END LOOP;

--- a/specs/predicate-rum.spec
+++ b/specs/predicate-rum.spec
@@ -26,7 +26,7 @@ setup
  FOR i in 1..338 LOOP
 	INSERT INTO rum_tbl(tsv) VALUES ('');
 	FOR j in 1..10 LOOP 
-		UPDATE rum_tbl SET tsv = tsv || (SELECT to_tsvector(t[1]) FROM text_table WHERE id1 = Xi % 676 + 1) WHERE id = i;
+		UPDATE rum_tbl SET tsv = tsv || (SELECT to_tsvector('simple', t[1]) FROM text_table WHERE id1 = Xi % 676 + 1) WHERE id = i;
 		Xi = (a * Xi + c) % m;
  	END LOOP;
  END LOOP;


### PR DESCRIPTION
tsvector can use different dictionaries. Their behavior is different, for example, the 'english' dictionary removes stop words.
Isolation tests generate a set of test data. The result may vary depending on which dictionary was used by the system.
Let's set the use of the 'simple' dictionary in the test to avoid ambiguity.