### PR TITLE
[PGPRO-11557] Fix infinite loop with multiple ORDER BY in RUM scan

### DIFF
--- a/src/rumget.c
+++ b/src/rumget.c
@@ -1741,7 +1741,11 @@ entryFindItem(RumState * rumstate, RumScanEntry entry, RumItem * item, Snapshot 
 	{
 		if (compareRumItemScanDirection(rumstate, entry->attnumOrig,
 							entry->scanDirection,
-							&entry->curItem, item) >= 0)
+							&entry->curItem, item) >= 0 &&
+							entry->offset >= 0 &&
+							entry->offset < entry->nlist &&
+							rumCompareItemPointers(&entry->curItem.iptr,
+												   &entry->list[entry->offset].iptr) == 0)
 			return;
 		while (entry->offset >= 0 && entry->offset < entry->nlist)
 		{


### PR DESCRIPTION
Fixes #66
Problem description:

When executing a query with ORDER BY col1, col2 using a RUM index, and the WHERE clause matches only a subset of the index, the query may enter an infinite loop in scanGetItemFast().

This occurs because entry->curItem is set via entry->curItem = collected.item;, but the corresponding entry->offset does not point to that item in entry->list. As a result, entryFindItem() may prematurely exit without correcting curItem, leading to repeated processing of the same item.
Fix:

Added an extra check in entryFindItem() that ensures:

    curItem >= item

    offset is within valid range

    entry->curItem.iptr == entry->list[offset].iptr

If the last condition fails, the function continues scanning the list to realign curItem and offset.

This ensures scanGetItemFast() progresses correctly and prevents infinite looping.