### PR TITLE
Add clang19 to Travis CI configuration

### DIFF
--- a/travis/Dockerfile.in
+++ b/travis/Dockerfile.in
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 	perl perl-ipc-run perl-dev perl-app-cpanminus perl-dbi \
 	make musl-dev gcc bison flex coreutils \
 	zlib-dev libedit-dev \
-	pkgconf icu-dev clang clang15 clang-analyzer;
+	pkgconf icu-dev clang clang15 clang19 clang-analyzer;
 
 # Environment
 ENV LANG=C.UTF-8 PGDATA=/pg/data


### PR DESCRIPTION
Some PostgreSQL packages have 'CLANG=clang-19' in CONFIGURE.
So Travis CI requires clang19 to avoid build faults.