### PR TITLE
[PGPRO-11480] Fix RUM tsquery evaluation with negated subtrees

### DIFF
--- a/expected/ruminv.out
+++ b/expected/ruminv.out
@@ -9,6 +9,7 @@ INSERT INTO test_invrum VALUES ('(a|b)&c'::tsquery);
 INSERT INTO test_invrum VALUES ('(!(a|b))&c'::tsquery);
 INSERT INTO test_invrum VALUES ('(a|b)&(c|d)'::tsquery);
 INSERT INTO test_invrum VALUES ('!a'::tsquery);
+INSERT INTO test_invrum VALUES ('a&!(b&c)'::tsquery);
 INSERT INTO test_invrum VALUES ('(a|a1|a2|a3|a4|a5)&(b|b1|b2|b3|b4|b5|b6)&!(c|c1|c2|c3)'::tsquery);
 SELECT * FROM test_invrum WHERE q @@ ''::tsvector;
        q        
@@ -20,12 +21,13 @@ SELECT * FROM test_invrum WHERE q @@ ''::tsvector;
 (4 rows)
 
 SELECT * FROM test_invrum WHERE q @@ 'a'::tsvector;
-       q        
-----------------
+          q           
+----------------------
  'a' | 'b'
  !( 'a' & 'b' )
  'a' & !'b'
-(3 rows)
+ 'a' & !( 'b' & 'c' )
+(4 rows)
 
 SELECT * FROM test_invrum WHERE q @@ 'b'::tsvector;
        q        
@@ -42,8 +44,9 @@ SELECT * FROM test_invrum WHERE q @@ 'a b'::tsvector;
  'a' | 'b'
  'a' & 'b'
  !'a' | 'b'
+ 'a' & !( 'b' & 'c' )
  ( 'a' | 'a1' | 'a2' | 'a3' | 'a4' | 'a5' ) & ( 'b' | 'b1' | 'b2' | 'b3' | 'b4' | 'b5' | 'b6' ) & !( 'c' | 'c1' | 'c2' | 'c3' )
-(4 rows)
+(5 rows)
 
 SELECT * FROM test_invrum WHERE q @@ 'c'::tsvector;
           q           
@@ -63,7 +66,8 @@ SELECT * FROM test_invrum WHERE q @@ 'a c'::tsvector;
  'a' & !'b'
  ( 'a' | 'b' ) & 'c'
  ( 'a' | 'b' ) & ( 'c' | 'd' )
-(5 rows)
+ 'a' & !( 'b' & 'c' )
+(6 rows)
 
 SELECT * FROM test_invrum WHERE q @@ 'b c'::tsvector;
                q               
@@ -102,7 +106,8 @@ SELECT * FROM test_invrum WHERE q @@ 'a d'::tsvector;
  !( 'a' & 'b' )
  'a' & !'b'
  ( 'a' | 'b' ) & ( 'c' | 'd' )
-(4 rows)
+ 'a' & !( 'b' & 'c' )
+(5 rows)
 
 SELECT * FROM test_invrum WHERE q @@ 'b d'::tsvector;
                q               
@@ -121,8 +126,9 @@ SELECT * FROM test_invrum WHERE q @@ 'a b d'::tsvector;
  'a' & 'b'
  !'a' | 'b'
  ( 'a' | 'b' ) & ( 'c' | 'd' )
+ 'a' & !( 'b' & 'c' )
  ( 'a' | 'a1' | 'a2' | 'a3' | 'a4' | 'a5' ) & ( 'b' | 'b1' | 'b2' | 'b3' | 'b4' | 'b5' | 'b6' ) & !( 'c' | 'c1' | 'c2' | 'c3' )
-(5 rows)
+(6 rows)
 
 SELECT * FROM test_invrum WHERE q @@ 'c d'::tsvector;
           q           
@@ -142,7 +148,8 @@ SELECT * FROM test_invrum WHERE q @@ 'a c d'::tsvector;
  'a' & !'b'
  ( 'a' | 'b' ) & 'c'
  ( 'a' | 'b' ) & ( 'c' | 'd' )
-(5 rows)
+ 'a' & !( 'b' & 'c' )
+(6 rows)
 
 CREATE INDEX test_invrum_idx ON test_invrum USING rum(q);
 SET enable_seqscan = OFF;
@@ -152,12 +159,13 @@ SELECT * FROM test_invrum WHERE q @@ ''::tsvector;
 (0 rows)
 
 SELECT * FROM test_invrum WHERE q @@ 'a'::tsvector;
-       q        
-----------------
+          q           
+----------------------
  'a' | 'b'
  !( 'a' & 'b' )
  'a' & !'b'
-(3 rows)
+ 'a' & !( 'b' & 'c' )
+(4 rows)
 
 SELECT * FROM test_invrum WHERE q @@ 'b'::tsvector;
        q        
@@ -216,7 +224,8 @@ SELECT * FROM test_invrum WHERE q @@ 'a b c'::tsvector;
  !'a' | 'b'
  ( 'a' | 'b' ) & 'c'
  ( 'a' | 'b' ) & ( 'c' | 'd' )
-(5 rows)
+ 'a' & !( 'b' & 'c' )
+(6 rows)
 
 SELECT * FROM test_invrum WHERE q @@ 'd'::tsvector;
        q        
@@ -234,7 +243,8 @@ SELECT * FROM test_invrum WHERE q @@ 'a d'::tsvector;
  !( 'a' & 'b' )
  'a' & !'b'
  ( 'a' | 'b' ) & ( 'c' | 'd' )
-(4 rows)
+ 'a' & !( 'b' & 'c' )
+(5 rows)
 
 SELECT * FROM test_invrum WHERE q @@ 'b d'::tsvector;
                q               

--- a/sql/ruminv.sql
+++ b/sql/ruminv.sql
@@ -10,6 +10,7 @@ INSERT INTO test_invrum VALUES ('(a|b)&c'::tsquery);
 INSERT INTO test_invrum VALUES ('(!(a|b))&c'::tsquery);
 INSERT INTO test_invrum VALUES ('(a|b)&(c|d)'::tsquery);
 INSERT INTO test_invrum VALUES ('!a'::tsquery);
+INSERT INTO test_invrum VALUES ('a&!(b&c)'::tsquery);
 INSERT INTO test_invrum VALUES ('(a|a1|a2|a3|a4|a5)&(b|b1|b2|b3|b4|b5|b6)&!(c|c1|c2|c3)'::tsquery);
 
 SELECT * FROM test_invrum WHERE q @@ ''::tsvector;

--- a/src/rumtsquery.c
+++ b/src/rumtsquery.c
@@ -94,6 +94,7 @@ make_query_item_wrap(QueryItem *item, QueryItemWrap *parent, bool not)
 
 					wrap->type = QI_OPR;
 					wrap->oper = oper;
+					wrap->not = not;
 
 					make_query_item_wrap(item + item->qoperator.left, wrap, not);
 					make_query_item_wrap(item + 1, wrap, not);


### PR DESCRIPTION
Set not flag for nested operator nodes in tsquery wrap tree. This ensures correct sum calculation for subtrees under NOT, allowing RUM to evaluate such queries properly during index scan.

Fixes: [issue123](https://github.com/postgrespro/rum/issues/123)

Tags: rum