### PR TITLE
[PGPRO-17316] Fixed a bug that appeared in e36d1644.

### DIFF
--- a/src/rumscan.c
+++ b/src/rumscan.c
@@ -473,7 +473,7 @@ lookupScanDirection(RumState *state, AttrNumber attno, StrategyNumber strategy)
 
 	for(i = 0; i < MAX_STRATEGIES; i++)
 	{
-		if (rumConfig->strategyInfo[i].strategy != InvalidStrategy)
+		if (rumConfig->strategyInfo[i].strategy == InvalidStrategy)
 			break;
 		if (rumConfig->strategyInfo[i].strategy == strategy)
 			return rumConfig->strategyInfo[i].direction;


### PR DESCRIPTION
A bug appeared in commit e36d1644, due to which, regardless of the strategy and type of the ORDER BY column, the NoMovementScanDirection direction was selected and the index followed the path with internal sorting.

The bug has been fixed in this commit. Now, if possible, RUM gets the items from the scan immediately in the correct order.

Tags: rum