### PR TITLE
PGPRO-18848; PGPRO-15138: Include htup_details.h to fix build with PG19

### DIFF
--- a/src/rumtidbitmap.h
+++ b/src/rumtidbitmap.h
@@ -15,6 +15,12 @@
 #define RUMTIDBITMAP_H
 
 #include "postgres.h"
+
+/*
+ * Since PG19 we need htup_details.h for tidbitmap.h to compile.
+ * See PostgreSQL commit 3bf31dd2 and discussion
+ */
+#include "access/htup_details.h"
 #include "nodes/tidbitmap.h"
 
 typedef struct TIDBitmap RumTIDBitmap;


### PR DESCRIPTION
Caused by:
- 3bf31dd2 (PostgreSQL) Do a tiny bit of header file maintenance

Note: There should be no harm from including it in lower versions too,
      so avoid using "#if PG_VERSION_NUM >= 190000"

Tags: rum